### PR TITLE
Add Jupyter notebook for mixed Gaussian distribution examples

### DIFF
--- a/samples/mixed_gaussian_distribution.ipynb
+++ b/samples/mixed_gaussian_distribution.ipynb
@@ -1,0 +1,119 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from catboost import CatBoostRegressor\n",
+    "from lightgbm import LGBMRegressor\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "\n",
+    "import sys\n",
+    "sys.path.append('../')\n",
+    "from ssbgm import ScoreBasedGenerator"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "np.random.seed(0)\n",
+    "N = 10000"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Case: 1d mixed gaussian\n",
+    "\n",
+    "# generate a training dataset\n",
+    "x_train = np.random.randn(N) + (2*(np.random.rand(N) > 0.5) - 1) * 1.6\n",
+    "\n",
+    "# train a generative model with score-based model\n",
+    "generative_model_1d_mixed_gaussian = ScoreBasedGenerator(LGBMRegressor(random_state=42)).fit(x_train, noise_strengths=np.sqrt(np.logspace(-3, np.log(x_train.var()), 101)))\n",
+    "\n",
+    "# generate samples from the trained model\n",
+    "x_gen = generative_model_1d_mixed_gaussian.sample(n_samples=N, sampling_method=ScoreBasedGenerator.SamplingMethod.EULER).squeeze()\n",
+    "\n",
+    "# plot the results\n",
+    "true_pdf = lambda x: 0.5*np.exp(-0.5*(x-1.6)**2)/np.sqrt(2*np.pi) + 0.5*np.exp(-0.5*(x+1.6)**2)/np.sqrt(2*np.pi)\n",
+    "plt.hist(x_train, bins=30, label='train data', color='blue', alpha=0.5, density=True)\n",
+    "plt.hist(x_gen, bins=30, label='generated data', color='red', alpha=0.5, density=True)\n",
+    "plt.plot(np.linspace(x_train.min(), x_train.max()), true_pdf(np.linspace(x_train.min(), x_train.max())), 'k-', label='true pdf')\n",
+    "plt.legend(loc='upper left')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Case: 2d mixed gaussian\n",
+    "\n",
+    "# generate a training dataset\n",
+    "X_train = np.random.randn(N, 2)\n",
+    "label = 2*(np.random.rand(N) > 0.5) - 1\n",
+    "X_train[:, 0] = X_train[:, 0] + label * 1.6\n",
+    "X_train[:, 1] = X_train[:, 1] + label * 1.6\n",
+    "\n",
+    "# train a generative model with score-based model\n",
+    "generative_model_2d_mixed_gaussian = ScoreBasedGenerator(\n",
+    "    estimator=CatBoostRegressor(\n",
+    "        verbose=0,\n",
+    "        loss_function='MultiRMSE',\n",
+    "        random_state=42,\n",
+    "    )\n",
+    ")\n",
+    "generative_model_2d_mixed_gaussian.fit(\n",
+    "    X_train,\n",
+    "    noise_strengths=np.sqrt(np.logspace(-3, np.log(max(np.var(X_train, axis=0))), 11)),\n",
+    ")\n",
+    "\n",
+    "# generate samples from the trained model\n",
+    "X_gen = generative_model_2d_mixed_gaussian.sample(n_samples=N, sampling_method=ScoreBasedGenerator.SamplingMethod.EULER).squeeze()\n",
+    "\n",
+    "# plot the results\n",
+    "true_pdf = lambda X: 0.5*np.exp(-0.5*(X[:, 0]-1.6)**2 - 0.5*(X[:, 1]-1.6)**2)/2/np.pi + 0.5*np.exp(-0.5*(X[:, 0]+1.6)**2 - 0.5*(X[:, 1]+1.6)**2)/2/np.pi\n",
+    "XX_, YY_ = np.meshgrid(np.linspace(X_train[:, 0].min(), X_train[:, 0].max()), np.linspace(X_train[:, 1].min(), X_train[:, 1].max()))\n",
+    "plt.scatter(X_train[:, 0], X_train[:, 1], label='train data', color='blue', alpha=0.2, marker='x')\n",
+    "plt.scatter(X_gen[:, 0], X_gen[:, 1], label='generated data', color='red', alpha=0.2, marker='o')\n",
+    "plt.contourf(XX_, YY_, true_pdf(np.c_[XX_.ravel(), YY_.ravel()]).reshape(XX_.shape), alpha=0.5)\n",
+    "plt.legend(loc='upper left')\n",
+    "plt.xlim(X_train[:, 0].min(), X_train[:, 0].max())\n",
+    "plt.ylim(X_train[:, 1].min(), X_train[:, 1].max())\n",
+    "plt.show()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Introduce a Jupyter notebook that demonstrates examples of mixed Gaussian distributions using score-based generative models. The notebook includes both 1D and 2D cases with visualizations of training and generated data.