### PR TITLE
Add build-system configuration to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,10 @@ dev = [
     "pytest-cov>=6.0.0",
 ]
 
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
 [tool.uv]
 dev-dependencies = [
     "autopep8>=2.3.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,10 @@ dev = [
 requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
 
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["ssbgm"]
+
 [tool.uv]
 dev-dependencies = [
     "autopep8>=2.3.1",


### PR DESCRIPTION
Introduce build-system configuration to specify dependencies for building the project.