### PR TITLE
Fix noise_strengths calculation and enhance tests

### DIFF
--- a/ssbgm/model.py
+++ b/ssbgm/model.py
@@ -140,7 +140,7 @@ class ScoreBasedGenerator(BaseEstimator):
 
         # preprocess noise_strengths
         if noise_strengths is None:
-            noise_strengths = np.sqrt(np.logspace(-3, y.var(axis=0).max(), 11))  # noqa
+            noise_strengths = np.sqrt(np.logspace(-3, np.log10(y.var(axis=0).max()), 11))  # noqa
 
         self.noise_strengths_ = noise_strengths
         self.n_outputs_ = y.shape[1] if y.ndim > 1 else 1

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -112,6 +112,13 @@ def test_ScoreBasedGenerator_fit(
     # TODO: test with sigmas and keep_noised_data kwargs
     ssg = ScoreBasedGenerator(estimator=LinearRegression())
     ssg.fit(X, y)
+    # check noise_strengths
+    if y is None:
+        assert max(ssg.noise_strengths_) == X.std(axis=0).max()
+    elif y.ndim == 1:
+        assert max(ssg.noise_strengths_) == y.std()
+    else:
+        assert max(ssg.noise_strengths_) == y.std(axis=0).max()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Update the calculation of noise_strengths to use log10 for maximum variance and add assertions in tests to verify the correctness based on input dimensions.