### PR TITLE
Add permissions for workflow jobs to read contents

### DIFF
--- a/.github/workflows/code-style-check-workflow-call.yaml
+++ b/.github/workflows/code-style-check-workflow-call.yaml
@@ -19,6 +19,8 @@ on:
 jobs:
   run-flake8:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12"]

--- a/.github/workflows/on-pull-request.yaml
+++ b/.github/workflows/on-pull-request.yaml
@@ -9,11 +9,17 @@ jobs:
     uses: ./.github/workflows/pytest-workflow-call.yaml
     with:
       git-ref: ${{ github.ref }}
+    permissions:
+      contents: read
   static-type-check:
     uses: ./.github/workflows/static-type-check-workflow-call.yaml
     with:
       git-ref: ${{ github.ref }}
+    permissions:
+      contents: read
   code-style-check:
     uses: ./.github/workflows/code-style-check-workflow-call.yaml
     with:
       git-ref: ${{ github.ref }}
+    permissions:
+      contents: read

--- a/.github/workflows/on-push.yaml
+++ b/.github/workflows/on-push.yaml
@@ -10,11 +10,17 @@ jobs:
     uses: ./.github/workflows/pytest-workflow-call.yaml
     with:
       git-ref: ${{ github.ref }}
+    permissions:
+      contents: read
   static-type-check:
     uses: ./.github/workflows/static-type-check-workflow-call.yaml
     with:
       git-ref: ${{ github.ref }}
+    permissions:
+      contents: read
   code-style-check:
     uses: ./.github/workflows/code-style-check-workflow-call.yaml
     with:
       git-ref: ${{ github.ref }}
+    permissions:
+      contents: read

--- a/.github/workflows/pytest-workflow-call.yaml
+++ b/.github/workflows/pytest-workflow-call.yaml
@@ -19,6 +19,8 @@ on:
 jobs:
   run-pytest:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12"]

--- a/.github/workflows/static-type-check-workflow-call.yaml
+++ b/.github/workflows/static-type-check-workflow-call.yaml
@@ -19,6 +19,8 @@ on:
 jobs:
   run-mypy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12"]

--- a/.github/workflows/tests-on-schedule.yaml
+++ b/.github/workflows/tests-on-schedule.yaml
@@ -8,7 +8,13 @@ on:
 jobs:
   test:
     uses: ./.github/workflows/pytest-workflow-call.yaml
+    permissions:
+      contents: read
   static-type-check:
     uses: ./.github/workflows/static-type-check-workflow-call.yaml
+    permissions:
+      contents: read
   code-style-check:
     uses: ./.github/workflows/code-style-check-workflow-call.yaml
+    permissions:
+      contents: read


### PR DESCRIPTION
Enhance workflow jobs by adding permissions to read repository contents, ensuring proper access for various tasks.